### PR TITLE
Removing `gcc` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -21,8 +24,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://github.com/bioidiap/bob.io.audio
 
 Package license: GNU General Public License v3 (GPLv3)
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Audio I/O support for Bob
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 831c4f8711949ce5f4180072d01494d4
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   script: python -B setup.py install --single-version-externally-managed --record record.txt
 
@@ -26,7 +26,6 @@ requirements:
   - bob.io.matlab
   - sox
   - pkg-config
-  - gcc     # [linux]
 
   run:
   - python
@@ -37,7 +36,6 @@ requirements:
   - bob.io.base
   - bob.io.matlab
   - sox
-  - libgcc  # [linux]
 
 test:
   imports:


### PR DESCRIPTION
We now have a C++11 capable `gcc` compiler in the docker image. It would be nice if you could do the following to try this.
1. Fork this repo.
2. Create a new branch
3. Remove `gcc` and `libgcc`.
4. Add, commit, push to your fork.
5. Open a PR to remove them.
6. Note in the PR that this issue is fixed by it.

Please ping me when you have done these things.
